### PR TITLE
fix variable syntax

### DIFF
--- a/rootfs/scripts/telegraf_input_readsb_protoc_range.sh
+++ b/rootfs/scripts/telegraf_input_readsb_protoc_range.sh
@@ -19,7 +19,7 @@ bearing=0
 
 # Pre-fill range array with "0"s to fix https://github.com/mikenye/docker-readsb-protobuf/issues/64
 for key in {71..0}; do
-  range[$key] = 0
+  range[$key]=0
 done
 
 for stat in "${stats_from_protoc[@]}"; do


### PR DESCRIPTION
Bash didn't like the spaces. Seems to work now.
No errors and the graph seems fine.